### PR TITLE
Use public vagrant box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,8 +5,12 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-    config.vm.box = "lvillani/win2008r2"
+    config.vm.box = "modernIE/w10-edge"
     config.vm.provision "shell", path: "bootstrap.cmd"
     config.vm.synced_folder ".", "/gopath/src/github.com/lvillani/just-install"
     config.vm.synced_folder "~/.ssh", "/Users/vagrant/Desktop/ssh"
+
+    config.vm.provider "virtualbox" do |v|
+      v.gui = true
+    end
 end

--- a/just-install.json
+++ b/just-install.json
@@ -190,6 +190,13 @@
       },
       "version": "0.2"
     },
+    "f.lux": {
+      "installer": {
+        "kind": "nsis",
+        "x86": "https://justgetflux.com/flux-setup.exe"
+      },
+      "version": "latest"
+    },
     "filezilla-server": {
       "installer": {
         "kind": "nsis",


### PR DESCRIPTION
If the intention is to use the Vagrant VM as a dev workspace, the box itself needs to be public.

For Virtualbox, open the GUI automatically.