### PR TITLE
Update libreoffice to 5.1.0

### DIFF
--- a/just-install.json
+++ b/just-install.json
@@ -453,7 +453,7 @@
         "x86": "http://download.documentfoundation.org/libreoffice/stable/{{.version}}/win/x86/LibreOffice_{{.version}}_Win_x86.msi",
         "x86_64": "http://download.documentfoundation.org/libreoffice/stable/{{.version}}/win/x86_64/LibreOffice_{{.version}}_Win_x64.msi"
       },
-      "version": "5.0.4"
+      "version": "5.1.0"
     },
     "lockhunter": {
       "installer": {


### PR DESCRIPTION
Updated the libreoffice version from 5.0.4 to 5.1.0. Right now just-install receives a 404.