### PR TITLE
Update google-chrome url and add x86_64 url

### DIFF
--- a/just-install.json
+++ b/just-install.json
@@ -443,7 +443,8 @@
     "google-chrome": {
       "installer": {
         "kind": "msi",
-        "x86": "https://dl.google.com/tag/s/appguid={8A69D345-D564-463C-AFF1-A69D9E530F96}&iid={00000000-0000-0000-0000-000000000000}&lang=en&browser=3&usagestats=0&appname=Google%2520Chrome&needsadmin=prefers/edgedl/chrome/install/GoogleChromeStandaloneEnterprise.msi"
+        "x86": "https://dl.google.com/tag/s/dl/chrome/install/googlechromestandaloneenterprise.msi",
+        "x86_64": "https://dl.google.com/tag/s/dl/chrome/install/googlechromestandaloneenterprise64.msi"
       },
       "version": "latest"
     },


### PR DESCRIPTION
It appears that the as google-chrome url has a lot of unnecessary tracking junk that can be stripped out with the download url still working perfectly well.