### PR TITLE
Update origin installer type to innosetup

### DIFF
--- a/just-install.json
+++ b/just-install.json
@@ -760,13 +760,7 @@
     },
     "origin": {
       "installer": {
-        "kind": "custom",
-        "options": {
-          "arguments": [
-            "{{.installer}}",
-            "-s"
-          ]
-        },
+        "kind": "innosetup",
         "x86": "https://eaassets-a.akamaihd.net/Origin-Client-Download/origin/live/OriginThinSetup.exe"
       },
       "version": "latest"


### PR DESCRIPTION
After discovering [this website](http://xetbox.com/?list=unattended) I noticed that the installer type for origin was listed as innosetup. 
After doing a quick test I confirmed it was in fact an innosetup installer and it installed completely silently!